### PR TITLE
Updating illuminate support dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "illuminate/support": "4.1.*"
+        "illuminate/support": "4.*"
     },
     "require-dev":{
         "phpunit/phpunit": "3.7.*"


### PR DESCRIPTION
4.1.\* is not compatible with Laravel 4.2._, updating dependency to just 4._

I don't know how to roll out this update, but I have a bug where I can't install this package because I have Laravel 4.2 and installing this package tried to roll back to 4.1, which Composer will not allow. Maybe you can roll it into your code? 
